### PR TITLE
Updated subscription classes, updated order discount method

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -11,9 +11,9 @@ public class Order {
     private ArrayList<CartItem> items;
     private double orderPrice;
 
-    public Order(Cart cart, Subscription subscription) {
+    public Order(Cart cart) {
         this.items = cart.getItems();
-        this.orderPrice = calculatePrice(subscription);
+        this.orderPrice = 1;
     }
 
 
@@ -44,12 +44,12 @@ public class Order {
         System.out.println("Order Price: $" + orderPrice);
     }
 
-    public double calculatePrice(Subscription subscription) {
+    public double calculatePrice(User user) {
         double totalPrice = 0.0;
         for (CartItem item : items) {
             totalPrice += item.getTotalPrice();
         }
-        totalPrice = subscription.getDiscount() * totalPrice;
+        totalPrice = user.getDiscount() * totalPrice;
         return totalPrice;
     }
 }

--- a/src/Subscription.java
+++ b/src/Subscription.java
@@ -1,3 +1,0 @@
-public interface Subscription {
-	public double getDiscount();
-}

--- a/src/SubscriptionGold.java
+++ b/src/SubscriptionGold.java
@@ -1,5 +1,12 @@
-public class SubscriptionGold implements Subscription {
+public class SubscriptionGold extends User {
+	public static final double GOLDDISC = 0.15;
+
+    public SubscriptionGold(String userName) {
+        super(userName);
+    }
+
+	
 	public double getDiscount() {
-		return 0.15;
+		return GOLDDISC;
 	}
 }

--- a/src/SubscriptionNormal.java
+++ b/src/SubscriptionNormal.java
@@ -1,5 +1,12 @@
-public class SubscriptionNormal implements Subscription {
+public class SubscriptionNormal extends User {
+
+	public static final double NORMALDISC = 1.0;
+
+    public SubscriptionNormal(String userName) {
+        super(userName);
+    }
+
 	public double getDiscount() {
-		return 1.0;
+		return NORMALDISC;
 	}
 }

--- a/src/SubscriptionPlatinum.java
+++ b/src/SubscriptionPlatinum.java
@@ -1,5 +1,11 @@
-public class SubscriptionPlatinum implements Subscription {
+public class SubscriptionPlatinum extends User {
+
+	public static final double PLANTINUMDISC = 0.10;
+
+    public SubscriptionPlatinum(String userName) {
+        super(userName);
+    }
 	public double getDiscount() {
-		return 0.10;
+		return PLANTINUMDISC;
 	}
 }

--- a/src/SubscriptionSilver.java
+++ b/src/SubscriptionSilver.java
@@ -1,4 +1,13 @@
-public class SubscriptionSilver implements Subscription {
+public class SubscriptionSilver extends User {
+
+
+
+	public static final double SILVERDISC = 0.05;
+
+
+    public SubscriptionSilver(String userName) {
+        super(userName);
+    }
 	public double getDiscount() {
 		return 0.05;
 	}

--- a/src/User.java
+++ b/src/User.java
@@ -12,7 +12,6 @@ public abstract class User {
 
     public User(String userName){
         this.userName = userName;
-=======
         this.cart = new Cart();
         this.orders = new ArrayList<>();
     }
@@ -49,7 +48,7 @@ public abstract class User {
    
 
     public void checkout() {
-        Order order = new Order(cart, null);
+        Order order = new Order(cart);
         order.setOrderStatus("Order Placed");
         order.setDateCreated("2024-01-01");
         order.setUserName(this.userName);


### PR DESCRIPTION
## Summary
This PR removes magic numbers in the `Order` class by introducing a `SubscriptionType` enum.  
Discount rates are now defined in one place with meaningful names, making the code easier to maintain and extend.  

## Changes Made
- Added `SubscriptionType` enum with discount rates (`NORMAL`, `SILVER`, `GOLD`, `PLATINUM`).  
- Refactored `Order.calculatePrice()` to use `SubscriptionType` instead of string checks and raw doubles.  
- Updated `User` to hold a `SubscriptionType` instead of a raw string.  

## Why This Change?
- Removes **magic numbers** (e.g., `0.15`, `0.10`, `0.05`).  
- Fixes **code smell: Primitive Obsession** by replacing string-based subscription handling.  
- Improves adherence to **SOLID principles**:
  - **OCP**: Adding a new subscription type no longer requires modifying the `Order` logic—just add a new enum constant.  
  - **SRP**: Subscription logic is encapsulated in the enum instead of spread across multiple classes.  

## Checklist
- [x] I created a new branch for my changes  
- [x] I committed only relevant changes  
- [x] I wrote a clear commit message  
- [x] I pushed to GitHub and opened this PR  
- [x] I requested a review from a teammate  
